### PR TITLE
#6

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
   before_action :authenticate_user, {only: [:show, :edit, :update]}
   before_action :forbid_login_user, {only: [:new, :create, :login_form, :login]}
-  before_action :ensure_correct_user, {only: [:edit, :update]}
+  before_action :ensure_correct_user, {only: [:edit, :update, :show]}
 
   def show
     @user = User.find_by(id: params[:id])

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -10,11 +10,7 @@
       <% end %>
       <div class="card">
         <div class="card-header">
-          <% if post.delete_flag == 1 %>
-            <%= "#{idx}. #{post.name}" %>
-          <% else %>
-            <%= link_to("#{idx}. #{post.name}", "/users/#{post.user_id}") %>
-          <% end %>
+          <%= "#{idx}. #{post.name}" %>
           <input type="hidden" name="id" value="<%= post.id %>">
           <% if @current_user && post.user_id == @current_user.id %>
             <%= link_to("削除",

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,10 +3,8 @@
   <div class="user">
     <h2><%= @user.name %></h2>
     <p><%= @user.email %></p>
-    <% if @user.id == @current_user.id %>
       <%= link_to("編集", "/users/#{@user.id}/edit",
                   {class: "btn btn-primary"}) %>
-    <% end %>
   </div>
 
   <div class="posts">
@@ -20,13 +18,11 @@
             <% post.image_name = nil %>
           <% end %>
             <li class="list-group-item">
-              <% if @current_user && post.user_id == @current_user.id %>
                 <%= link_to("削除",
                             "/users/delete_post/#{post.id}",
                             {method: "post",
                              data: {confirm: "削除してもよろしいですか？"},
                              class: "badge badge-secondary float-right"}) %>
-              <% end %>
               <%= link_to(Topic.find_by(id: post.topic_id).title,
                           "/topics/show/#{post.topic_id}",
                           class: "title") %><br>


### PR DESCRIPTION
` current_user `でないとマイページを見られないようにした。また、マイページ上での` current_user `判定を無くし、常に編集ボタンと書込削除ボタンを表示。